### PR TITLE
fixing missing include causing unknown 'unique_ptr' in legacy/gnupg/g10/keyid.cpp

### DIFF
--- a/legacy/gnupg/g10/keyid.cpp
+++ b/legacy/gnupg/g10/keyid.cpp
@@ -27,6 +27,8 @@
 #include <errno.h>
 #include <time.h>
 
+#include <memory>
+
 #include <botan/hash.h>
 
 #include "gpg.h"


### PR DESCRIPTION
Getting a build issue on FC26 causes compiling error:

legacy/gnupg/g10/keyid.cpp:581:12: error: ‘unique_ptr’ is not a member of ‘std’
       std::unique_ptr<Botan::HashFunction> rmd160(Botan::HashFunction::create_or_throw("RIPEMD-160"));

Fixed by including <memory>