### PR TITLE
Remove unused functions from libgpg-error.

### DIFF
--- a/legacy/CMakeLists.txt
+++ b/legacy/CMakeLists.txt
@@ -15,7 +15,6 @@ add_library(gpg-error
   libgpg-error/src/estream.cpp
   libgpg-error/src/estream-printf.cpp
   libgpg-error/src/gpg-error.h
-  libgpg-error/src/gpgrt.h
   libgpg-error/src/gpgrt-int.h
   libgpg-error/src/init.cpp
   libgpg-error/src/visibility.h

--- a/legacy/libgpg-error/src/gpg-error.h
+++ b/legacy/libgpg-error/src/gpg-error.h
@@ -865,11 +865,6 @@ typedef struct _gpgrt_syshd es_syshd_t;
 
 gpgrt_stream_t gpgrt_fopen(const char *_GPGRT__RESTRICT path,
                            const char *_GPGRT__RESTRICT mode);
-gpgrt_stream_t gpgrt_mopen(void *_GPGRT__RESTRICT data, size_t data_n,
-                           size_t data_len, unsigned int grow,
-                           void *(*func_realloc)(void *mem, size_t size),
-                           void (*func_free)(void *mem),
-                           const char *_GPGRT__RESTRICT mode);
 gpgrt_stream_t gpgrt_fopenmem(size_t memlimit,
                               const char *_GPGRT__RESTRICT mode);
 gpgrt_stream_t gpgrt_fopenmem_init(size_t memlimit,
@@ -997,12 +992,8 @@ int gpgrt_vasprintf(char **r_buf, const char *_GPGRT__RESTRICT format,
 int gpgrt_snprintf(char *buf, size_t bufsize,
                    const char *_GPGRT__RESTRICT format, ...)
     GPGRT_ATTR_PRINTF(3, 4);
-int gpgrt_vsnprintf(char *buf, size_t bufsize,
-                    const char *_GPGRT__RESTRICT format, va_list arg_ptr)
-    GPGRT_ATTR_PRINTF(3, 0);
 
 #define es_fopen gpgrt_fopen
-#define es_mopen gpgrt_mopen
 #define es_fopenmem gpgrt_fopenmem
 #define es_fopenmem_init gpgrt_fopenmem_init
 #define es_fdopen gpgrt_fdopen

--- a/legacy/libgpg-error/src/gpgrt-int.h
+++ b/legacy/libgpg-error/src/gpgrt-int.h
@@ -127,11 +127,6 @@ void _gpgrt_get_syscall_clamp(void (**r_pre)(void), void (**r_post)(void));
 
 gpgrt_stream_t _gpgrt_fopen(const char *_GPGRT__RESTRICT path,
                             const char *_GPGRT__RESTRICT mode);
-gpgrt_stream_t _gpgrt_mopen(void *_GPGRT__RESTRICT data, size_t data_n,
-                            size_t data_len, unsigned int grow,
-                            void *(*func_realloc)(void *mem, size_t size),
-                            void (*func_free)(void *mem),
-                            const char *_GPGRT__RESTRICT mode);
 gpgrt_stream_t _gpgrt_fopenmem(size_t memlimit,
                                const char *_GPGRT__RESTRICT mode);
 gpgrt_stream_t _gpgrt_fopenmem_init(size_t memlimit,

--- a/legacy/libgpg-error/src/gpgrt.h
+++ b/legacy/libgpg-error/src/gpgrt.h
@@ -1,1 +1,0 @@
-#include <gpg-error.h>

--- a/legacy/libgpg-error/src/visibility.cpp
+++ b/legacy/libgpg-error/src/visibility.cpp
@@ -44,15 +44,6 @@ estream_t gpgrt_fopen(const char *_GPGRT__RESTRICT path,
   return _gpgrt_fopen(path, mode);
 }
 
-estream_t gpgrt_mopen(void *_GPGRT__RESTRICT data, size_t data_n,
-                      size_t data_len, unsigned int grow,
-                      void *(*func_realloc)(void *mem, size_t size),
-                      void (*func_free)(void *mem),
-                      const char *_GPGRT__RESTRICT mode) {
-  return _gpgrt_mopen(data, data_n, data_len, grow, func_realloc, func_free,
-                      mode);
-}
-
 estream_t gpgrt_fopenmem(size_t memlimit, const char *_GPGRT__RESTRICT mode) {
   return _gpgrt_fopenmem(memlimit, mode);
 }
@@ -296,11 +287,6 @@ int gpgrt_snprintf(char *buf, size_t bufsize, const char *format, ...) {
   va_end(arg_ptr);
 
   return rc;
-}
-
-int gpgrt_vsnprintf(char *buf, size_t bufsize, const char *format,
-                    va_list arg_ptr) {
-  return _gpgrt_estream_vsnprintf(buf, bufsize, format, arg_ptr);
 }
 
 #include <string.h>

--- a/legacy/libgpg-error/src/visibility.h
+++ b/legacy/libgpg-error/src/visibility.h
@@ -45,7 +45,6 @@
 #define gpg_err_set_errno _gpgrt_USE_UNDERSCORED_FUNCTION
 
 #define gpgrt_fopen _gpgrt_USE_UNDERSCORED_FUNCTION
-#define gpgrt_mopen _gpgrt_USE_UNDERSCORED_FUNCTION
 #define gpgrt_fopenmem _gpgrt_USE_UNDERSCORED_FUNCTION
 #define gpgrt_fopenmem_init _gpgrt_USE_UNDERSCORED_FUNCTION
 #define gpgrt_fdopen _gpgrt_USE_UNDERSCORED_FUNCTION
@@ -98,7 +97,6 @@
 #define gpgrt_asprintf _gpgrt_USE_UNDERSCORED_FUNCTION
 #define gpgrt_vasprintf _gpgrt_USE_UNDERSCORED_FUNCTION
 #define gpgrt_snprintf _gpgrt_USE_UNDERSCORED_FUNCTION
-#define gpgrt_vsnprintf _gpgrt_USE_UNDERSCORED_FUNCTION
 
 #define gpgrt_set_syscall_clamp _gpgrt_USE_UNDERSCORED_FUNCTION
 #define gpgrt_get_syscall_clamp _gpgrt_USE_UNDERSCORED_FUNCTION


### PR DESCRIPTION
These functions are now unused.