### PR TITLE
Remove PKA support.

### DIFF
--- a/legacy/gnupg/g10/call-dirmngr.cpp
+++ b/legacy/gnupg/g10/call-dirmngr.cpp
@@ -994,55 +994,6 @@ leave:
   return err;
 }
 
-/* Ask the dirmngr for PKA info.  On success the retrieved fingerprint
-   is returned in a malloced buffer at R_FPR and its length is stored
-   at R_FPRLEN.  If an URL is available it is stored as a malloced
-   string at R_URL.  On error all return values are set to NULL/0.  */
-gpg_error_t gpg_dirmngr_get_pka(ctrl_t ctrl, const char *userid,
-                                unsigned char **r_fpr, size_t *r_fprlen,
-                                char **r_url) {
-  gpg_error_t err;
-  assuan_context_t ctx;
-  struct dns_cert_parm_s parm;
-  std::string line;
-
-  memset(&parm, 0, sizeof parm);
-  if (r_fpr) *r_fpr = NULL;
-  if (r_fprlen) *r_fprlen = 0;
-  if (r_url) *r_url = NULL;
-
-  err = open_context(ctrl, &ctx);
-  if (err) return err;
-
-  line = "DNS_CERT --pka -- ";
-  line += userid;
-  if (line.size() + 2 >= ASSUAN_LINELENGTH) {
-    err = GPG_ERR_TOO_LARGE;
-    goto leave;
-  }
-
-  err = assuan_transact(ctx, line.c_str(), dns_cert_data_cb, &parm, NULL, NULL,
-                        dns_cert_status_cb, &parm);
-  if (err) goto leave;
-
-  if (r_fpr && parm.fpr) {
-    *r_fpr = parm.fpr;
-    parm.fpr = NULL;
-  }
-  if (r_fprlen) *r_fprlen = parm.fprlen;
-
-  if (r_url && parm.url) {
-    *r_url = parm.url;
-    parm.url = NULL;
-  }
-
-leave:
-  xfree(parm.fpr);
-  xfree(parm.url);
-  close_context(ctrl, ctx);
-  return err;
-}
-
 /* Ask the dirmngr to retrieve a key via the Web Key Directory
  * protocol.  If QUICK is set the dirmngr is advised to use a shorter
  * timeout.  On success a new estream with the key is stored at R_KEY.

--- a/legacy/gnupg/g10/call-dirmngr.h
+++ b/legacy/gnupg/g10/call-dirmngr.h
@@ -37,9 +37,6 @@ gpg_error_t gpg_dirmngr_dns_cert(ctrl_t ctrl, const char *name,
                                  const char *certtype, estream_t *r_key,
                                  unsigned char **r_fpr, size_t *r_fprlen,
                                  char **r_url);
-gpg_error_t gpg_dirmngr_get_pka(ctrl_t ctrl, const char *userid,
-                                unsigned char **r_fpr, size_t *r_fprlen,
-                                char **r_url);
 gpg_error_t gpg_dirmngr_wkd_get(ctrl_t ctrl, const char *name, int quick,
                                 estream_t *r_key);
 

--- a/legacy/gnupg/g10/free-packet.cpp
+++ b/legacy/gnupg/g10/free-packet.cpp
@@ -60,10 +60,6 @@ void free_seckey_enc(PKT_signature *sig) {
   xfree(sig->hashed);
   xfree(sig->unhashed);
 
-  if (sig->pka_info) {
-    xfree(sig->pka_info->uri);
-    xfree(sig->pka_info);
-  }
   xfree(sig->signers_uid);
 
   xfree(sig);
@@ -161,17 +157,6 @@ PKT_public_key *copy_public_key(PKT_public_key *d, PKT_public_key *s) {
   return d;
 }
 
-static pka_info_t *cp_pka_info(const pka_info_t *s) {
-  pka_info_t *d = (pka_info_t *)xmalloc(sizeof *s + strlen(s->email));
-
-  d->valid = s->valid;
-  d->checked = s->checked;
-  d->uri = s->uri ? xstrdup(s->uri) : NULL;
-  memcpy(d->fpr, s->fpr, sizeof s->fpr);
-  strcpy(d->email, s->email);
-  return d;
-}
-
 PKT_signature *copy_signature(PKT_signature *d, PKT_signature *s) {
   int n, i;
 
@@ -183,7 +168,6 @@ PKT_signature *copy_signature(PKT_signature *d, PKT_signature *s) {
   else {
     for (i = 0; i < n; i++) d->data[i] = my_mpi_copy(s->data[i]);
   }
-  d->pka_info = s->pka_info ? cp_pka_info(s->pka_info) : NULL;
   d->hashed = cp_subpktarea(s->hashed);
   d->unhashed = cp_subpktarea(s->unhashed);
   if (s->signers_uid) d->signers_uid = xstrdup(s->signers_uid);

--- a/legacy/gnupg/g10/getkey.cpp
+++ b/legacy/gnupg/g10/getkey.cpp
@@ -1143,13 +1143,6 @@ int get_pubkey_byname(ctrl_t ctrl, GETKEY_CTX *retctx, PKT_public_key *pk,
           glo_ctrl.in_auto_key_retrieve--;
           break;
 
-        case AKL_PKA:
-          mechanism = "PKA";
-          glo_ctrl.in_auto_key_retrieve++;
-          rc = keyserver_import_pka(ctrl, name, &fpr, &fpr_len);
-          glo_ctrl.in_auto_key_retrieve--;
-          break;
-
         case AKL_DANE:
           mechanism = "DANE";
           glo_ctrl.in_auto_key_retrieve++;
@@ -1202,7 +1195,7 @@ int get_pubkey_byname(ctrl_t ctrl, GETKEY_CTX *retctx, PKT_public_key *pk,
       /* Use the fingerprint of the key that we actually fetched.
        * This helps prevent problems where the key that we fetched
        * doesn't have the same name that we used to fetch it.  In
-       * the case of CERT and PKA, this is an actual security
+       * the case of CERT, this is an actual security
        * requirement as the URL might point to a key put in by an
        * attacker.  By forcing the use of the fingerprint, we
        * won't use the attacker's key here. */
@@ -3588,8 +3581,6 @@ int parse_auto_key_locate(char *options) {
       akl->type = AKL_KEYSERVER;
     else if (ascii_strcasecmp(tok, "cert") == 0)
       akl->type = AKL_CERT;
-    else if (ascii_strcasecmp(tok, "pka") == 0)
-      akl->type = AKL_PKA;
     else if (ascii_strcasecmp(tok, "dane") == 0)
       akl->type = AKL_DANE;
     else if (ascii_strcasecmp(tok, "wkd") == 0)

--- a/legacy/gnupg/g10/gpg.cpp
+++ b/legacy/gnupg/g10/gpg.cpp
@@ -330,7 +330,6 @@ enum cmd_and_opt_values {
   oEnableDSA2,
   oDisableDSA2,
   oFakedSystemTime,
-  oPrintPKARecords,
   oPrintDANERecords,
   oDefaultNewKeyAlgo,
   oWeakDigest,
@@ -625,7 +624,6 @@ const static ARGPARSE_OPTS opts[] = {
     ARGPARSE_s_n(oAllowFreeformUID, "allow-freeform-uid", "@"),
     ARGPARSE_s_n(oNoAllowFreeformUID, "no-allow-freeform-uid", "@"),
     ARGPARSE_s_n(oListOnly, "list-only", "@"),
-    ARGPARSE_s_n(oPrintPKARecords, "print-pka-records", "@"),
     ARGPARSE_s_n(oPrintDANERecords, "print-dane-records", "@"),
     ARGPARSE_s_n(oIgnoreTimeConflict, "ignore-time-conflict", "@"),
     ARGPARSE_s_n(oIgnoreValidFrom, "ignore-valid-from", "@"),
@@ -2316,10 +2314,6 @@ next_pass:
              N_("show revoked and expired user IDs in signature verification")},
             {"show-primary-uid-only", VERIFY_SHOW_PRIMARY_UID_ONLY, NULL,
              N_("show only the primary user ID in signature verification")},
-            {"pka-lookups", VERIFY_PKA_LOOKUPS, NULL,
-             N_("validate signatures with PKA data")},
-            {"pka-trust-increase", VERIFY_PKA_TRUST_INCREASE, NULL,
-             N_("elevate the trust of signatures with valid PKA data")},
             {NULL, 0, NULL, NULL}};
 
         if (!parse_options(pargs.r.ret_str, &opt.verify_options, vopts, 1)) {

--- a/legacy/gnupg/g10/keyserver-internal.h
+++ b/legacy/gnupg/g10/keyserver-internal.h
@@ -46,8 +46,6 @@ gpg_error_t keyserver_search(ctrl_t ctrl,
 int keyserver_fetch(ctrl_t ctrl, const std::vector<std::string> &urilist);
 int keyserver_import_cert(ctrl_t ctrl, const char *name, int dane_mode,
                           unsigned char **fpr, size_t *fpr_len);
-gpg_error_t keyserver_import_pka(ctrl_t ctrl, const char *name,
-                                 unsigned char **fpr, size_t *fpr_len);
 gpg_error_t keyserver_import_wkd(ctrl_t ctrl, const char *name, int quick,
                                  unsigned char **fpr, size_t *fpr_len);
 int keyserver_import_name(ctrl_t ctrl, const char *name, unsigned char **fpr,

--- a/legacy/gnupg/g10/keyserver.cpp
+++ b/legacy/gnupg/g10/keyserver.cpp
@@ -95,8 +95,6 @@ static struct parse_options keyserver_opts[] = {
      N_("automatically retrieve keys when verifying signatures")},
     {"honor-keyserver-url", KEYSERVER_HONOR_KEYSERVER_URL, NULL,
      N_("honor the preferred keyserver URL set on the key")},
-    {"honor-pka-record", KEYSERVER_HONOR_PKA_RECORD, NULL,
-     N_("honor the PKA record set on a key when retrieving keys")},
     {NULL, 0, NULL, NULL}};
 
 static gpg_error_t keyserver_get(ctrl_t ctrl, KEYDB_SEARCH_DESC *desc,
@@ -1679,34 +1677,6 @@ int keyserver_import_cert(ctrl_t ctrl, const char *name, int dane_mode,
 
   xfree(url);
   xfree(look);
-
-  return err;
-}
-
-/* Import key pointed to by a PKA record. Return the requested
-   fingerprint in fpr. */
-gpg_error_t keyserver_import_pka(ctrl_t ctrl, const char *name,
-                                 unsigned char **fpr, size_t *fpr_len) {
-  gpg_error_t err;
-  char *url;
-
-  err = gpg_dirmngr_get_pka(ctrl, name, fpr, fpr_len, &url);
-  if (url && *url && fpr && fpr_len) {
-    /* An URL is available.  Lookup the key. */
-    struct keyserver_spec *spec;
-    spec = parse_keyserver_uri(url, 1);
-    if (spec) {
-      err = keyserver_import_fprint(ctrl, *fpr, *fpr_len, spec, 0);
-      free_keyserver_spec(spec);
-    }
-  }
-  xfree(url);
-
-  if (err) {
-    xfree(*fpr);
-    *fpr = NULL;
-    *fpr_len = 0;
-  }
 
   return err;
 }

--- a/legacy/gnupg/g10/mainproc.cpp
+++ b/legacy/gnupg/g10/mainproc.cpp
@@ -1282,70 +1282,6 @@ leave:
   return rc;
 }
 
-/* Helper for pka_uri_from_sig to parse the to-be-verified address out
-   of the notation data. */
-static pka_info_t *get_pka_address(PKT_signature *sig) {
-  pka_info_t *pka = NULL;
-  struct notation *nd, *notation;
-
-  notation = sig_to_notation(sig);
-
-  for (nd = notation; nd; nd = nd->next) {
-    if (strcmp(nd->name, "pka-address@gnupg.org") != 0)
-      continue; /* Not the notation we want. */
-
-    /* For now we only use the first valid PKA notation. In future
-       we might want to keep additional PKA notations in a linked
-       list. */
-    if (is_valid_mailbox(nd->value)) {
-      pka = (pka_info_t *)xmalloc(sizeof *pka + strlen(nd->value));
-      pka->valid = 0;
-      pka->checked = 0;
-      pka->uri = NULL;
-      strcpy(pka->email, nd->value);
-      break;
-    }
-  }
-
-  free_notation(notation);
-
-  return pka;
-}
-
-/* Return the URI from a DNS PKA record.  If this record has already
-   be retrieved for the signature we merely return it; if not we go
-   out and try to get that DNS record. */
-static const char *pka_uri_from_sig(CTX c, PKT_signature *sig) {
-  if (!sig->flags.pka_tried) {
-    log_assert(!sig->pka_info);
-    sig->flags.pka_tried = 1;
-    sig->pka_info = get_pka_address(sig);
-    if (sig->pka_info) {
-      char *url;
-      unsigned char *fpr;
-      size_t fprlen;
-
-      if (!gpg_dirmngr_get_pka(c->ctrl, sig->pka_info->email, &fpr, &fprlen,
-                               &url)) {
-        if (fpr && fprlen == sizeof sig->pka_info->fpr) {
-          memcpy(sig->pka_info->fpr, fpr, fprlen);
-          if (url) {
-            sig->pka_info->valid = 1;
-            if (!*url)
-              xfree(url);
-            else
-              sig->pka_info->uri = url;
-            url = NULL;
-          }
-        }
-        xfree(fpr);
-        xfree(url);
-      }
-    }
-  }
-  return sig->pka_info ? sig->pka_info->uri : NULL;
-}
-
 /* Return true if the AKL has the WKD method specified.  */
 static int akl_has_wkd_method(void) {
   struct akl *akl;
@@ -1551,32 +1487,6 @@ static int check_sig_and_print(CTX c, kbnode_t node) {
 
           if (!rc) break;
         }
-      }
-    }
-  }
-
-  /* If the avove methods didn't work, our next try is to use the URI
-   * from a DNS PKA record.  */
-  if (rc == GPG_ERR_NO_PUBKEY &&
-      (opt.keyserver_options.options & KEYSERVER_AUTO_KEY_RETRIEVE) &&
-      (opt.keyserver_options.options & KEYSERVER_HONOR_PKA_RECORD)) {
-    const char *uri = pka_uri_from_sig(c, sig);
-
-    if (uri) {
-      /* FIXME: We might want to locate the key using the
-         fingerprint instead of the keyid. */
-      int res;
-      struct keyserver_spec *spec;
-
-      spec = parse_keyserver_uri(uri, 1);
-      if (spec) {
-        free_public_key(pk);
-        pk = NULL;
-        glo_ctrl.in_auto_key_retrieve++;
-        res = keyserver_import_keyid(c->ctrl, sig->keyid, spec, 1);
-        glo_ctrl.in_auto_key_retrieve--;
-        free_keyserver_spec(spec);
-        if (!res) rc = do_check_sig(c, node, NULL, &is_expkey, &is_revkey, &pk);
       }
     }
   }
@@ -1819,8 +1729,6 @@ static int check_sig_and_print(CTX c, kbnode_t node) {
 
     /* For good signatures compute and print the trust information.  */
     if (!rc) {
-      if ((opt.verify_options & VERIFY_PKA_LOOKUPS))
-        pka_uri_from_sig(c, sig); /* Make sure PKA info is available. */
       rc = check_signatures_trust(c->ctrl, sig);
     }
 

--- a/legacy/gnupg/g10/options.h
+++ b/legacy/gnupg/g10/options.h
@@ -56,7 +56,6 @@ enum {
   AKL_NODEFAULT,
   AKL_LOCAL,
   AKL_CERT,
-  AKL_PKA,
   AKL_DANE,
   AKL_WKD,
   AKL_LDAP,
@@ -138,7 +137,6 @@ extern int memory_stat_debug_mode;
 #define EXPORT_RESET_SUBKEY_PASSWD (1 << 3)
 #define EXPORT_MINIMAL (1 << 4)
 #define EXPORT_CLEAN (1 << 5)
-#define EXPORT_PKA_FORMAT (1 << 6)
 #define EXPORT_DANE_FORMAT (1 << 7)
 #define EXPORT_BACKUP (1 << 10)
 
@@ -163,8 +161,6 @@ extern int memory_stat_debug_mode;
 #define VERIFY_SHOW_KEYSERVER_URLS (1 << 4)
 #define VERIFY_SHOW_UID_VALIDITY (1 << 5)
 #define VERIFY_SHOW_UNUSABLE_UIDS (1 << 6)
-#define VERIFY_PKA_LOOKUPS (1 << 7)
-#define VERIFY_PKA_TRUST_INCREASE (1 << 8)
 #define VERIFY_SHOW_PRIMARY_UID_ONLY (1 << 9)
 
 #define KEYSERVER_HTTP_PROXY (1 << 0)
@@ -172,7 +168,6 @@ extern int memory_stat_debug_mode;
 #define KEYSERVER_ADD_FAKE_V3 (1 << 2)
 #define KEYSERVER_AUTO_KEY_RETRIEVE (1 << 3)
 #define KEYSERVER_HONOR_KEYSERVER_URL (1 << 4)
-#define KEYSERVER_HONOR_PKA_RECORD (1 << 5)
 
 /* Global options for GPG.  */
 struct options {
@@ -263,7 +258,7 @@ struct options {
   unsigned char s2k_count{0};          /* Auto-calibrate when needed.  */
   keyserver_spec_t keyserver{nullptr}; /* The list of configured keyservers.  */
   struct {
-    unsigned int options{KEYSERVER_HONOR_PKA_RECORD};
+    unsigned int options{0};
     unsigned int import_options{
         (IMPORT_REPAIR_KEYS | IMPORT_REPAIR_PKS_SUBKEY_BUG)};
     unsigned int export_options{EXPORT_ATTRIBUTES};

--- a/legacy/gnupg/g10/packet.h
+++ b/legacy/gnupg/g10/packet.h
@@ -172,17 +172,6 @@ struct revocation_key {
   byte fpr[MAX_FINGERPRINT_LEN];
 };
 
-/* Object to keep information about a PKA DNS record. */
-typedef struct {
-  int valid;             /* An actual PKA record exists for EMAIL. */
-  int checked;           /* Set to true if the FPR has been checked against the
-                            actual key. */
-  char *uri;             /* Malloced string with the URI. NULL if the URI is
-                            not available.*/
-  unsigned char fpr[20]; /* The fingerprint as stored in the PKA RR. */
-  char email[1];         /* The email address from the notation data. */
-} pka_info_t;
-
 /* A signature packet (RFC 4880, Section 5.2).  Only a subset of these
    fields are directly serialized (these are marked as such); the rest
    are read from the subpackets, which are not synthesized when
@@ -200,7 +189,6 @@ typedef struct {
     unsigned notation : 1;   /* At least one notation is present */
     unsigned pref_ks : 1;    /* At least one preferred keyserver is present */
     unsigned expired : 1;
-    unsigned pka_tried : 1; /* Set if we tried to retrieve the PKA record. */
   } flags;
   /* The key that allegedly generated this signature.  (Directly
      serialized in v3 sigs; for v4 sigs, this must be explicitly added
@@ -227,8 +215,6 @@ typedef struct {
   const byte *trust_regexp;
   struct revocation_key *revkey;
   int numrevkeys;
-  pka_info_t *pka_info;   /* Malloced PKA data or NULL if not
-                             available.  See also flags.pka_tried. */
   char *signers_uid;      /* Malloced value of the SIGNERS_UID
                            * subpacket or NULL.  This string has
                            * already been sanitized.  */

--- a/legacy/gnupg/g10/pkclist.cpp
+++ b/legacy/gnupg/g10/pkclist.cpp
@@ -532,53 +532,6 @@ int check_signatures_trust(ctrl_t ctrl, PKT_signature *sig) {
   if ((trustlevel & TRUST_FLAG_DISABLED))
     log_info(_("Note: This key has been disabled.\n"));
 
-  /* If we have PKA information adjust the trustlevel. */
-  if (sig->pka_info && sig->pka_info->valid) {
-    unsigned char fpr[MAX_FINGERPRINT_LEN];
-    PKT_public_key *primary_pk;
-    size_t fprlen;
-    int okay;
-
-    primary_pk = (PKT_public_key *)xmalloc_clear(sizeof *primary_pk);
-    get_pubkey(ctrl, primary_pk, pk->main_keyid);
-    fingerprint_from_pk(primary_pk, fpr, &fprlen);
-    free_public_key(primary_pk);
-
-    if (fprlen == 20 && !memcmp(sig->pka_info->fpr, fpr, 20)) {
-      okay = 1;
-      write_status_text(STATUS_PKA_TRUST_GOOD, sig->pka_info->email);
-      log_info(_("Note: Verified signer's address is '%s'\n"),
-               sig->pka_info->email);
-    } else {
-      okay = 0;
-      write_status_text(STATUS_PKA_TRUST_BAD, sig->pka_info->email);
-      log_info(_("Note: Signer's address '%s' "
-                 "does not match DNS entry\n"),
-               sig->pka_info->email);
-    }
-
-    switch ((trustlevel & TRUST_MASK)) {
-      case TRUST_UNKNOWN:
-      case TRUST_UNDEFINED:
-      case TRUST_MARGINAL:
-        if (okay && opt.verify_options & VERIFY_PKA_TRUST_INCREASE) {
-          trustlevel = ((trustlevel & ~TRUST_MASK) | TRUST_FULLY);
-          log_info(
-              _("trustlevel adjusted to FULL"
-                " due to valid PKA info\n"));
-        }
-      /* fall through */
-      case TRUST_FULLY:
-        if (!okay) {
-          trustlevel = ((trustlevel & ~TRUST_MASK) | TRUST_NEVER);
-          log_info(
-              _("trustlevel adjusted to NEVER"
-                " due to bad PKA info\n"));
-        }
-        break;
-    }
-  }
-
   /* Now let the user know what up with the trustlevel. */
   switch ((trustlevel & TRUST_MASK)) {
     case TRUST_EXPIRED:

--- a/legacy/gnupg/sm/keylist.cpp
+++ b/legacy/gnupg/sm/keylist.cpp
@@ -176,7 +176,6 @@ static struct {
     {"2.16.840.1.113730.1.13", "netscape-comment"},
 
     /* GnuPG extensions */
-    {"1.3.6.1.4.1.11591.2.1.1", "pkaAddress"},
     {"1.3.6.1.4.1.11591.2.2.1", "standaloneCertificate"},
     {"1.3.6.1.4.1.11591.2.2.2", "wellKnownPrivateKey"},
 


### PR DESCRIPTION
PKA is a proposal for automatic public key retrieval over DNS by Werner Koch. These seem to be the authoritative documents:
* http://g10code.com/docs/pka-intro.de.pdf
* https://lists.gnupg.org/pipermail/gnupg-devel/2015-February/029544.html

I am removing the support for this proposal from NeoPG:
* There is very little adoption. Checking 642 email addresses from Debian maintainers shows only 8 PKA entries (and 22 TXT entries that are not PKA).  Of these 8, several are expired keys (including the one from Simon Joseffson) or the URL is not reachable.
* There is no standard or draft of a standard, or other process towards standardization.
* All arguments against key retrieval via DNS apply (web bugs, lack of security in DNS, lack of control for users over DNS, difficulty of setting up DNS records, etc).

In the future, NeoPG will provide an API to extend key retrieval and trust evaluation, allowing such experimental protocols to be included in applications without tainting the core code base.