### PR TITLE
Remove support for preferred keyserver.

### DIFF
--- a/docs/openpgp.md
+++ b/docs/openpgp.md
@@ -21,6 +21,20 @@ level.
 
 4.3. Packet Tags
 
+5.2.3.18. Preferred Key Server
+
+* Preferred Key Server Packets MUST not be generatd.
+* Preferred Key Server Packets MUST be ignored.
+
+NOTE: Preferred key servers have not seen wide adoption, and they can
+be used to violate the privacy of the recipient.  The standard allows
+to set multiple preferred key servers on multiple user ids, which is
+ambiguous.  The meaning of the URI in the field is left open to
+interpretation.  Thus, existing preferred key servers in signature and
+in user id signatures must be ignored and new ones must not be
+generated.
+
+
 5.7. Symmetrically Encrypted Data Packet
 
 * Symmetrically Encrypted Data Packets MUST not be generated.

--- a/legacy/gnupg/g10/build-packet.cpp
+++ b/legacy/gnupg/g10/build-packet.cpp
@@ -821,10 +821,6 @@ void build_sig_subpkt(PKT_signature *sig, sigsubpkttype_t type,
       sig->flags.policy_url = 1;
       break;
 
-    case SIGSUBPKT_PREF_KS:
-      sig->flags.pref_ks = 1;
-      break;
-
     case SIGSUBPKT_EXPORTABLE:
       if (buffer[0])
         sig->flags.exportable = 1;

--- a/legacy/gnupg/g10/call-dirmngr.cpp
+++ b/legacy/gnupg/g10/call-dirmngr.cpp
@@ -132,22 +132,6 @@ static gpg_error_t create_context(ctrl_t ctrl, assuan_context_t *r_ctx) {
   }
 
   if (err)
-    ;
-  else if ((opt.keyserver_options.options & KEYSERVER_HONOR_KEYSERVER_URL)) {
-    /* Tell the dirmngr that this possibly privacy invading
-       option is in use.  If Dirmngr is running in Tor mode, it
-       will return an error.  */
-    err = assuan_transact(ctx, "OPTION honor-keyserver-url-used", NULL, NULL,
-                          NULL, NULL, NULL, NULL);
-    if (err == GPG_ERR_FORBIDDEN)
-      log_error(
-          _("keyserver option \"honor-keyserver-url\""
-            " may not be used in Tor mode\n"));
-    else if (err == GPG_ERR_UNKNOWN_OPTION)
-      err = 0; /* Old dirmngr versions do not support this option.  */
-  }
-
-  if (err)
     assuan_release(ctx);
   else {
     *r_ctx = ctx;

--- a/legacy/gnupg/g10/keygen.cpp
+++ b/legacy/gnupg/g10/keygen.cpp
@@ -86,7 +86,6 @@ enum para_name {
   pSERIALNO,
   pCARDBACKUPKEY,
   pHANDLE,
-  pKEYSERVER,
   pKEYGRIP
 };
 
@@ -574,7 +573,6 @@ int keygen_upd_std_prefs(PKT_signature *sig, void *opaque) {
   /* Make sure that the MDC feature flag is set if needed.  */
   add_feature_mdc(sig, mdc_available);
   add_keyserver_modify(sig, ks_modify);
-  keygen_add_keyserver_url(sig, NULL);
 
   return 0;
 }
@@ -589,20 +587,6 @@ int keygen_add_std_prefs(PKT_signature *sig, void *opaque) {
   do_add_key_flags(sig, pk->pubkey_usage);
   keygen_add_key_expire(sig, opaque);
   keygen_upd_std_prefs(sig, opaque);
-  keygen_add_keyserver_url(sig, NULL);
-
-  return 0;
-}
-
-int keygen_add_keyserver_url(PKT_signature *sig, void *opaque) {
-  const char *url = (const char *)opaque;
-
-  if (!url && opt.def_keyserver_url) url = opt.def_keyserver_url->c_str();
-
-  if (url)
-    build_sig_subpkt(sig, SIGSUBPKT_PREF_KS, (const byte *)(url), strlen(url));
-  else
-    delete_sig_subpkt(sig->hashed, SIGSUBPKT_PREF_KS);
 
   return 0;
 }
@@ -2963,22 +2947,6 @@ static int proc_parameter_file(ctrl_t ctrl, struct para_data_s *para,
   /* Set preferences, if any. */
   keygen_set_std_prefs(get_parameter_value(para, pPREFERENCES), 0);
 
-  /* Set keyserver, if any. */
-  s1 = get_parameter_value(para, pKEYSERVER);
-  if (s1) {
-    struct keyserver_spec *spec;
-
-    spec = parse_keyserver_uri(s1, 1);
-    if (spec) {
-      free_keyserver_spec(spec);
-      opt.def_keyserver_url = s1;
-    } else {
-      r = get_parameter(para, pKEYSERVER);
-      log_error("%s:%d: invalid keyserver url\n", fname, r->lnr);
-      return -1;
-    }
-  }
-
   /* Set revoker, if any. */
   if (parse_revocation_key(fname, para, pREVOKER)) return -1;
 
@@ -3045,7 +3013,6 @@ static void read_parameter_file(ctrl_t ctrl, const char *fname) {
                   {"Preferences", (para_name)pPREFERENCES},
                   {"Revoker", (para_name)pREVOKER},
                   {"Handle", (para_name)pHANDLE},
-                  {"Keyserver", (para_name)pKEYSERVER},
                   {"Keygrip", (para_name)pKEYGRIP},
                   {NULL, (para_name)0}};
   IOBUF fp;

--- a/legacy/gnupg/g10/keylist.cpp
+++ b/legacy/gnupg/g10/keylist.cpp
@@ -285,42 +285,6 @@ void show_policy_url(PKT_signature *sig, int indent, int mode) {
   }
 }
 
-/* Print a keyserver URL.  Allowed values for MODE are:
- *  -1 - print to the TTY
- *   0 - print to stdout.
- *   1 - use log_info and emit status messages.
- *   2 - emit only status messages.
- */
-void show_keyserver_url(PKT_signature *sig, int indent, int mode) {
-  const byte *p;
-  size_t len;
-  int seq = 0, crit;
-  estream_t fp = mode < 0 ? NULL : mode ? log_get_stream() : es_stdout;
-
-  while ((
-      p = enum_sig_subpkt(sig->hashed, SIGSUBPKT_PREF_KS, &len, &seq, &crit))) {
-    if (mode != 2) {
-      const char *str;
-
-      tty_fprintf(fp, "%*s", indent, "");
-
-      if (crit)
-        str = _("Critical preferred keyserver: ");
-      else
-        str = _("Preferred keyserver: ");
-      if (mode > 0)
-        log_info("%s", str);
-      else
-        tty_fprintf(fp, "%s", str);
-      tty_print_utf8_string2(fp, p, len, 0);
-      tty_fprintf(fp, "\n");
-    }
-
-    if (mode > 0)
-      status_one_subpacket(SIGSUBPKT_PREF_KS, len, (crit ? 0x02 : 0) | 0x01, p);
-  }
-}
-
 /* Print notation data.  Allowed values for MODE are:
  *  -1 - print to the TTY
  *   0 - print to stdout.
@@ -920,9 +884,6 @@ static void list_keyblock_print(ctrl_t ctrl, kbnode_t keyblock, int secret,
             sig, 3, 0,
             ((opt.list_options & LIST_SHOW_STD_NOTATIONS) ? 1 : 0) +
                 ((opt.list_options & LIST_SHOW_USER_NOTATIONS) ? 2 : 0));
-
-      if (sig->flags.pref_ks && (opt.list_options & LIST_SHOW_KEYSERVER_URLS))
-        show_keyserver_url(sig, 3, 0);
 
       /* fixme: check or list other sigs here */
     }

--- a/legacy/gnupg/g10/main.h
+++ b/legacy/gnupg/g10/main.h
@@ -431,7 +431,6 @@ void list_keyblock_direct(ctrl_t ctrl, kbnode_t keyblock, int secret,
 void print_fingerprint(ctrl_t ctrl, estream_t fp, PKT_public_key *pk, int mode);
 void print_revokers(estream_t fp, PKT_public_key *pk);
 void show_policy_url(PKT_signature *sig, int indent, int mode);
-void show_keyserver_url(PKT_signature *sig, int indent, int mode);
 void show_notation(PKT_signature *sig, int indent, int mode, int which);
 void dump_attribs(const PKT_user_id *uid, PKT_public_key *pk);
 void set_attrib_fd(int fd);

--- a/legacy/gnupg/g10/options.h
+++ b/legacy/gnupg/g10/options.h
@@ -157,7 +157,6 @@ extern int memory_stat_debug_mode;
 #define KEYSERVER_TIMEOUT (1 << 1)
 #define KEYSERVER_ADD_FAKE_V3 (1 << 2)
 #define KEYSERVER_AUTO_KEY_RETRIEVE (1 << 3)
-#define KEYSERVER_HONOR_KEYSERVER_URL (1 << 4)
 
 /* Global options for GPG.  */
 struct options {

--- a/legacy/gnupg/g10/packet.h
+++ b/legacy/gnupg/g10/packet.h
@@ -187,7 +187,6 @@ typedef struct {
     unsigned revocable : 1;
     unsigned policy_url : 1; /* At least one policy URL is present */
     unsigned notation : 1;   /* At least one notation is present */
-    unsigned pref_ks : 1;    /* At least one preferred keyserver is present */
     unsigned expired : 1;
   } flags;
   /* The key that allegedly generated this signature.  (Directly

--- a/legacy/gnupg/g10/parse-packet.cpp
+++ b/legacy/gnupg/g10/parse-packet.cpp
@@ -1261,10 +1261,6 @@ static void dump_sig_subpkt(int hashed, int type, int critical,
       for (i = 0; i < length; i++)
         *listfp << boost::format(" %02X") % buffer[i];
       break;
-    case SIGSUBPKT_PREF_KS:
-      *listfp << "preferred keyserver: ";
-      write_sanitized(*listfp, buffer, length);
-      break;
     case SIGSUBPKT_PRIMARY_UID:
       p = "primary user ID";
       break;
@@ -1707,9 +1703,6 @@ int parse_signature(IOBUF inp, int pkttype, unsigned long pktlen,
 
     p = parse_sig_subpkt(sig->hashed, SIGSUBPKT_POLICY, NULL);
     if (p) sig->flags.policy_url = 1;
-
-    p = parse_sig_subpkt(sig->hashed, SIGSUBPKT_PREF_KS, NULL);
-    if (p) sig->flags.pref_ks = 1;
 
     p = parse_sig_subpkt(sig->hashed, SIGSUBPKT_SIGNERS_UID, &len);
     if (p && len) {

--- a/legacy/gnupg/g10/sign.cpp
+++ b/legacy/gnupg/g10/sign.cpp
@@ -120,28 +120,6 @@ static void mk_notation_policy_etc(PKT_signature *sig, PKT_public_key *pk,
     }
   }
 
-  /* Preferred keyserver URL. */
-  if (IS_SIG(sig)) {
-    for (auto &&pu_ : opt.sig_keyserver_url) {
-      string = pu_.first.c_str();
-      unsigned int flags = pu_.second;
-
-      p = pct_expando(string, &args);
-      if (!p) {
-        log_error(
-            _("WARNING: unable to %%-expand preferred keyserver URL"
-              " (too large).  Using unexpanded.\n"));
-        p = xstrdup(string);
-      }
-
-      build_sig_subpkt(
-          sig, (sigsubpkttype_t)((SIGSUBPKT_PREF_KS |
-                                  ((flags & 1) ? SIGSUBPKT_FLAG_CRITICAL : 0))),
-          (const byte *)(p), strlen(p));
-      xfree(p);
-    }
-  }
-
   /* Set signer's user id.  */
   if (IS_SIG(sig) && !opt.flags.disable_signer_uid) {
     char *mbox;


### PR DESCRIPTION
Preferred keyservers can be used in data signatures and user id signatures, and allow the signer to provide one (or more) URIs that supposedly can be used to lookup or refresh the public key of the signer (refreshing is important to check for revocations).

This is a severe misfeature, and NeoPG removes support for it, because of the following reasons:
* Automatic use of the field can violate the privacy of the recipient.
* It is disabled by default in GnuPG for this reason.
* The preferred keyserver subpacket has not been widely adopted.  Of 855 Debian maintainer keys, only 16 (1.9%) have such subpackets.  I don't have any data on their use in signatures, but for GnuPG to retrieve the key automatically based on these subpackets, both auto-key-locate and honor-keyserver-url must be true.
* The standard is unclear on the interpretation and semantic of this field.  Of the 18 URIs among the Debian keys, one points to `https://pgp.mit.edu/pks/lookup?op=vindex&search=0xE9E28DEA00AA5556`, which is not a keyserver, but a lookup URL for this particular key on that keyserver. Another uses the URI scheme `x-hkp`, while the others use `hkp`, `hkps` or `http`. Those indicating `http` do not have the correct port (11371) for hkp access.  And only 2 indicate secure access via TLS with hkps or https, while the others indicate unprotected access via hkp or http, irregardless of the current status of https/hkps support on the server.  
* Because these subpackets are attached to user id signatures, there can be several different on them, further complicating interpretation.  In fact, of the 16 Debian keys two keys have signatures with two different keyserver urls: 

```
Giovanni Mascellani:
spk:24:1:25:hkp%3A//keyserver.uz.sns.it (part of the SKS pool)
(6 times)
spk:24:1:24:hkp%3A//keyserver.linux.it (no DNS entry)
(4 times)

Raphaël Hertzog <raphael@ouaza.com>
spk:24:1:20:hkp%3A//keys.gnupg.net (alias for SKS pool)
(2 times)
spk:24:1:24:hkp%3A//keyring.debian.org
(1 time)
```
I have not checked the expiration and revocation status to see if those would help in this particular case.  In general, it can be arbitrary complicated.
* Of the 18 URIs among the Debian keys, we find (ignoring differences in scheme and so on) 11 different hostnames.  Of these, 3 are not reachable at this time, 7 are reachable with hkp and hkps, and one is only reachable via hkp.  All but 2 are part of the SKS pool.

The API of libneopg will provide low-level access to this information, if it exists, which might be sufficient for some users who want to experiment with them.  In case it is desirable to do key lookup based on signatures containing keyserver information, it would be important to involve the user anyway, and not do it automatically behind the scenes.
