### PR TITLE
Remove special tor mode.

### DIFF
--- a/legacy/gnupg/dirmngr/dirmngr.cpp
+++ b/legacy/gnupg/dirmngr/dirmngr.cpp
@@ -90,7 +90,7 @@ enum cmd_and_opt_values {
   oDisableIPv6,
   oIgnoreHTTPDP,
   oIgnoreOCSPSvcUrl,
-  oHonorHTTPProxy,
+  oNoHTTPProxy,
   oHTTPProxy,
   oOCSPResponder,
   oOCSPSigner,
@@ -178,7 +178,7 @@ static ARGPARSE_OPTS opts[] = {
     ARGPARSE_s_n(oNoGreeting, "no-greeting", "@"),
     ARGPARSE_s_s(oHomedir, "homedir", "@"),
     ARGPARSE_s_s(oHTTPWrapperProgram, "http-wrapper-program", "@"),
-    ARGPARSE_s_n(oHonorHTTPProxy, "honor-http-proxy", "@"),
+    ARGPARSE_s_n(oNoHTTPProxy, "no-http-proxy", "@"),
     ARGPARSE_s_s(oIgnoreCertExtension, "ignore-cert-extension", "@"),
     ARGPARSE_s_i(oConnectTimeout, "connect-timeout", "@"),
     ARGPARSE_s_i(oConnectQuickTimeout, "connect-quick-timeout", "@"),
@@ -405,8 +405,8 @@ static int parse_rereadable_options(ARGPARSE_ARGS *pargs, int reread) {
     case oDisableIPv6:
       opt.disable_ipv6 = 1;
       break;
-    case oHonorHTTPProxy:
-      opt.honor_http_proxy = 1;
+    case oNoHTTPProxy:
+      opt.honor_http_proxy = 0;
       break;
     case oHTTPProxy:
       opt.http_proxy = pargs->r.ret_str;

--- a/legacy/gnupg/dirmngr/dirmngr.h
+++ b/legacy/gnupg/dirmngr/dirmngr.h
@@ -81,7 +81,7 @@ struct dirmngr_options {
   int disable_http{0};            /* Do not use HTTP at all.  */
   int disable_ipv4{0};            /* Do not use legacy IP addresses.  */
   int disable_ipv6{0};            /* Do not use standard IP addresses.  */
-  int honor_http_proxy{0};        /* Honor the http_proxy env variable. */
+  int honor_http_proxy{1};        /* Honor the http_proxy env variable. */
   const char *http_proxy{0};      /* The default HTTP proxy.  */
   int ignore_http_dp{0};          /* Ignore HTTP CRL distribution points.  */
   int ignore_ocsp_service_url{0}; /* Ignore OCSP service URLs as given in

--- a/legacy/gnupg/dirmngr/dns-stuff.cpp
+++ b/legacy/gnupg/dirmngr/dns-stuff.cpp
@@ -89,13 +89,3 @@ legacy:
   }
   return (ndots == 3) ? 4 : 0;
 }
-
-/* Return true if NAME is an onion address.  */
-int is_onion_address(const char *name) {
-  size_t len;
-
-  len = name ? strlen(name) : 0;
-  if (len < 8 || strcmp(name + len - 6, ".onion")) return 0;
-  /* Note that we require at least 2 characters before the suffix.  */
-  return 1; /* Yes.  */
-}

--- a/legacy/gnupg/dirmngr/dns-stuff.h
+++ b/legacy/gnupg/dirmngr/dns-stuff.h
@@ -33,7 +33,4 @@
 /* Return true if NAME is a numerical IP address.  */
 int is_ip_address(const char *name);
 
-/* Return true if NAME is an onion address.  */
-int is_onion_address(const char *name);
-
 #endif /*GNUPG_DIRMNGR_DNS_STUFF_H*/

--- a/legacy/gnupg/dirmngr/http.cpp
+++ b/legacy/gnupg/dirmngr/http.cpp
@@ -96,7 +96,6 @@ static gpg_error_t do_parse_uri(parsed_uri_t uri, int only_local_part,
   uri->port = 0;
   uri->is_http = 0;
   uri->v6lit = 0;
-  uri->onion = 0;
 
   /* A quick validity check. */
   if (strspn(p, VALID_URI_CHARS) != n)
@@ -165,8 +164,6 @@ static gpg_error_t do_parse_uri(parsed_uri_t uri, int only_local_part,
     }
 
   } /* End global URI part. */
-
-  if (is_onion_address(uri->host)) uri->onion = 1;
 
   return 0;
 }

--- a/legacy/gnupg/dirmngr/http.h
+++ b/legacy/gnupg/dirmngr/http.h
@@ -40,7 +40,6 @@ struct parsed_uri_s {
   char *scheme; /* Pointer to the scheme string (always lowercase). */
   unsigned int is_http : 1; /* This is a HTTP style URI.   */
   unsigned int v6lit : 1;   /* Host was given as a literal v6 address.  */
-  unsigned int onion : 1;   /* .onion address given.  */
   char *auth;               /* username/password for basic auth.  */
   char *host;               /* Host (converted to lowercase). */
   unsigned short port;      /* Port (always set if the host is set). */


### PR DESCRIPTION
Now that we do not require custom DNS lookups (which meant using a local dns resolver in GnuPG that uses TCP over Tor), what's left of GnuPG's Tor support is preferring .onion keyserver addresses over non-onion addresses if Tor is available.  Let's stipulate that for now people who know how to configure a Tor proxy can also set an .onion keyserver URL, if they want to use one.
With this change, you can use NeoPG with Tor just like any other application, simply by configuring the SOCKS5H proxy and setting the corresponding environment variables or proxy configuration options.
I also set the default of dirmngr to honor http proxy environment variables, so Tor will be used by default if configured.  Also, this will make it more compatible with network configurations that require the use of a proxy.  Also, the option --honor-http-proxy was renamed to --no-http-proxy with the opposite meaning (disable all http proxy use).