### PR TITLE
[WIP] Implement new subcommand curl.

### DIFF
--- a/lib/proto/http.h
+++ b/lib/proto/http.h
@@ -16,10 +16,10 @@
 namespace NeoPG {
 
 class NEOPG_UNSTABLE_API Http {
-  const long MAX_REDIRECTS_DEFAULT = 2;
-  const long MAX_FILESIZE_DEFAULT = 2 * 1024 * 1024;
-
  public:
+  static const long MAX_REDIRECTS_DEFAULT{2};
+  static const long MAX_FILESIZE_DEFAULT{2 * 1024 * 1024};
+
   Http();
 
   Http& forbid_reuse(bool no_reuse = true);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ set(NeopgToolHeaders
   cli/cat_command.h
   cli/command.h
   cli/compress_command.h
+  cli/curl_command.h
   cli/hash_command.h
   cli/packet_command.h
   cli/random_command.h
@@ -23,6 +24,7 @@ add_library(neopg-tool STATIC
   cli/cat_command.cpp
   cli/command.cpp
   cli/compress_command.cpp
+  cli/curl_command.cpp
   cli/hash_command.cpp
   cli/packet_command.cpp
   cli/random_command.cpp

--- a/src/cli/curl_command.cpp
+++ b/src/cli/curl_command.cpp
@@ -1,0 +1,25 @@
+/* NeoPG
+   Copyright 2017 The NeoPG developers
+
+   NeoPG is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <iostream>
+
+#include <neopg-tool/curl_command.h>
+#include <neopg/http.h>
+
+namespace NeoPG {
+
+void CurlCommand::run() {
+  NeoPG::Http request;
+  request.set_url(m_url)
+      .set_maxfilesize(m_max_filesize)
+      .set_redirects(m_max_redirects)
+      .no_cache(m_nocache);
+
+  std::string response = request.fetch();
+  std::cout.write((const char*)response.data(), response.size());
+}
+
+}  // Namespace NeoPG

--- a/src/cli/curl_command.h
+++ b/src/cli/curl_command.h
@@ -1,0 +1,34 @@
+/* Command line parsing
+   Copyright 2017 The NeoPG developers
+
+   NeoPG is released under the Simplified BSD License (see license.txt)
+*/
+
+#pragma once
+
+#include <neopg-tool/command.h>
+#include <neopg/http.h>
+
+namespace NeoPG {
+
+class CurlCommand : public Command {
+ public:
+  long m_max_filesize{NeoPG::Http::MAX_FILESIZE_DEFAULT};
+  long m_max_redirects{NeoPG::Http::MAX_REDIRECTS_DEFAULT};
+  bool m_nocache{false};
+  std::string m_url;
+  void run() override;
+  CurlCommand(CLI::App& app, const std::string& flag,
+              const std::string& description,
+              const std::string& group_name = "")
+      : Command(app, flag, description, group_name) {
+    m_cmd.add_option("url", m_url, "URL of resource to fetch")->required();
+    m_cmd.add_option("--max-redirs", m_max_redirects,
+                     "maximum number of redirects", true);
+    m_cmd.add_option("--max-filesize", m_max_filesize, "maximum file size",
+                     true);
+    m_cmd.add_flag("--no-cache", m_nocache, "do not use proxy data");
+  }
+};
+
+}  // Namespace NeoPG

--- a/src/neopg.cpp
+++ b/src/neopg.cpp
@@ -33,6 +33,7 @@ static void setup_locale() {
 #include <neopg-tool/cat_command.h>
 #include <neopg-tool/command.h>
 #include <neopg-tool/compress_command.h>
+#include <neopg-tool/curl_command.h>
 #include <neopg-tool/hash_command.h>
 #include <neopg-tool/packet_command.h>
 #include <neopg-tool/random_command.h>
@@ -152,6 +153,7 @@ int main(int argc, char* argv[]) {
   PacketCommand cmd_packet(app, "packet", "read and write OpenPGP packets",
                            tools_group);
   RandomCommand cmd_random(app, "random", "output random bytes", tools_group);
+  CurlCommand cmd_curl(app, "curl", "fetch an URL", tools_group);
   HashCommand cmd_hash(app, "hash", "calculate hash function", tools_group);
   CompressCommand cmd_compress(app, "compress", "compress and decompress data",
                                tools_group);


### PR DESCRIPTION
This adds a new subcommand, "curl", for the toolbox that fetches an URL (similar to curl command line tool).  Fixes #39. Missing features:

* [ ] connect-to
* [ ] timeout
* [ ] post data
* [ ] cainfo
* [ ] proxy settings

The proxy settings should be done on the global option scope, and propagate to dirmngr, curl and other subcommands.

