### PR TITLE
Build libneopg as shared library, and fix interface visibility.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,25 @@
-# NeoPG - tests
-#   Copyright 2017 The NeoPG developers
+# NeoPG - cmake file
+# Copyright 2017 The NeoPG developers
 #
 # NeoPG is released under the Simplified BSD License (see license.txt)
 
-# Cmake setup.
 cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+
+# Get version number before calling project().
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(GitVersion)
 set(NeoPG_VERSION_STRING "${GIT_VERSION_STRING}")
 set(NeoPG_VERSION_STRING_FULL "${GIT_VERSION_STRING_FULL}")
 
-project(NeoPG VERSION "${NeoPG_VERSION_STRING}")
+project(NeoPG VERSION "${NeoPG_VERSION_STRING}" LANGUAGES CXX)
 message(STATUS "${PROJECT_NAME} ${${PROJECT_NAME}_VERSION_STRING_FULL}")
 
-# targets: release, changelog
+# Add targets for maintainers: release, changelog
 include(GitRelease)
+
+# Add user-settable options.
+option(BUILD_SHARED_LIBS "Build shared libraries." ON)
+
 
 # Compiler setup.
 

--- a/cmake/GitVersion.cmake
+++ b/cmake/GitVersion.cmake
@@ -1,3 +1,13 @@
+# NeoPG - cmake file
+# Copyright 2017 The NeoPG developers
+#
+# NeoPG is released under the Simplified BSD License (see license.txt)
+
+# This file defines two variables:
+# - GIT_VERSION_STRING with the format "1.2.3" usable for cmake project()
+# - GIT_VERSION_STRING_FULL with the format "v1.2.3-TAG-NUMBER-ID-dirty"
+# where any part but the version number may be omitted (see git-describe).
+
 find_package(Git)
 
 set(GIT_VERSION_STRING_FULL "")
@@ -9,16 +19,16 @@ if(GIT_FOUND)
        # this case we might not have a version number after all.
        COMMAND ${GIT_EXECUTABLE} describe --tags --dirty --always
        OUTPUT_VARIABLE GIT_VERSION_STRING_FULL
-       RESULT_VARIABLE GIT_DESCRIBE_RESULT
+       RESULT_VARIABLE GIT_VERSION_DESCRIBE_RESULT
        OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 else()
-  set(GIT_DESCRIBE_RESULT -1)
+  set(GIT_VERSION_DESCRIBE_RESULT -1)
 endif()
 
 # In case we couldn't find a version tag with git, we add the one from
 # the file VERSION.
-if(NOT GIT_DESCRIBE_RESULT EQUAL 0 OR NOT GIT_VERSION_STRING_FULL MATCHES "^v[0-9]+\.[0-9]+\.[0-9]+")
+if(NOT GIT_VERSION_DESCRIBE_RESULT EQUAL 0 OR NOT GIT_VERSION_STRING_FULL MATCHES "^v[0-9]+\.[0-9]+\.[0-9]+")
   # CMAKE_SOURCE_DIR is valid even before project() is called.
   file(READ ${CMAKE_SOURCE_DIR}/VERSION VERSION_STRING)
   string(STRIP "${VERSION_STRING}" VERSION_STRING)

--- a/include/neopg/common.h
+++ b/include/neopg/common.h
@@ -7,3 +7,22 @@
 #pragma once
 
 #define NEOPG_DLL __attribute__((visibility("default")))
+
+/**
+* Interfaces annotated with this API are stable and supported.
+* @param maj The major version for the initial release of this API.
+* @param min The minor version for the initial release of this API.
+*/
+#define NEOPG_PUBLIC_API(maj, min) NEOPG_DLL
+
+/**
+* Interfaces annotated with this API are supported, but they are
+* experimental and can change in incompatible ways.
+*/
+#define NEOPG_UNSTABLE_API NEOPG_DLL
+
+/**
+ * Interfaces annotated with this API are only exported for internal
+ * reasons, and should not be used otherwise.
+*/
+#define NEOPG_TEST_API NEOPG_DLL

--- a/include/neopg/crypto/rng.h
+++ b/include/neopg/crypto/rng.h
@@ -8,10 +8,12 @@
 
 #include <botan/rng.h>
 
+#include <neopg/common.h>
+
 namespace NeoPG {
 namespace Crypto {
 
-Botan::RandomNumberGenerator* rng(void);
+NEOPG_DLL Botan::RandomNumberGenerator* rng(void);
 
 }  // Namespace CLI
 }  // Namespace NeoPG

--- a/include/neopg/openpgp/compressed_data_packet.h
+++ b/include/neopg/openpgp/compressed_data_packet.h
@@ -12,7 +12,7 @@
 namespace NeoPG {
 namespace OpenPGP {
 
-enum class CompressionAlgorithm : uint8_t {
+enum class NEOPG_UNSTABLE_API CompressionAlgorithm : uint8_t {
   Uncompressed = 0x00,
   Deflate = 0x01,
   Zlib = 0x02,
@@ -30,7 +30,7 @@ enum class CompressionAlgorithm : uint8_t {
   Private_110 = 0x6e,
 };
 
-struct CompressedDataPacket : Packet {
+struct NEOPG_UNSTABLE_API CompressedDataPacket : Packet {
   void write_body(std::ostream& out) const override;
   PacketType type() const override;
 
@@ -40,7 +40,7 @@ struct CompressedDataPacket : Packet {
 
 /* Uncompressed Data Packet.  */
 
-struct UncompressedDataPacket : CompressedDataPacket {
+struct NEOPG_UNSTABLE_API UncompressedDataPacket : CompressedDataPacket {
   std::vector<uint8_t> m_data;
   void write_compressed_data(std::ostream& out) const override;
   CompressionAlgorithm compression_algorithm() const override;
@@ -48,7 +48,7 @@ struct UncompressedDataPacket : CompressedDataPacket {
 
 /* Deflate Compressed Data Packet.  */
 
-struct DeflateCompressedDataPacket : CompressedDataPacket {
+struct NEOPG_UNSTABLE_API DeflateCompressedDataPacket : CompressedDataPacket {
   std::vector<uint8_t> m_data;
   void write_compressed_data(std::ostream& out) const override;
   CompressionAlgorithm compression_algorithm() const override;
@@ -56,7 +56,7 @@ struct DeflateCompressedDataPacket : CompressedDataPacket {
 
 /* Zlib Compressed Data Packet.  */
 
-struct ZlibCompressedDataPacket : CompressedDataPacket {
+struct NEOPG_UNSTABLE_API ZlibCompressedDataPacket : CompressedDataPacket {
   std::vector<uint8_t> m_data;
   void write_compressed_data(std::ostream& out) const override;
   CompressionAlgorithm compression_algorithm() const override;
@@ -64,7 +64,7 @@ struct ZlibCompressedDataPacket : CompressedDataPacket {
 
 /* Bzip2 Compressed Data Packet.  */
 
-struct Bzip2CompressedDataPacket : CompressedDataPacket {
+struct NEOPG_UNSTABLE_API Bzip2CompressedDataPacket : CompressedDataPacket {
   std::vector<uint8_t> m_data;
   void write_compressed_data(std::ostream& out) const override;
   CompressionAlgorithm compression_algorithm() const override;

--- a/include/neopg/openpgp/header.h
+++ b/include/neopg/openpgp/header.h
@@ -10,10 +10,12 @@
 #include <iostream>
 #include <stdexcept>
 
+#include <neopg/common.h>
+
 namespace NeoPG {
 namespace OpenPGP {
 
-enum class PacketType : uint8_t {
+enum class NEOPG_UNSTABLE_API PacketType : uint8_t {
   Reserved = 0,
   PublicKeyEncryptedSessionKey = 1,
   Signature = 2,
@@ -38,7 +40,7 @@ enum class PacketType : uint8_t {
   Private_63 = 63
 };
 
-enum class PacketLengthType : uint8_t {
+enum class NEOPG_UNSTABLE_API PacketLengthType : uint8_t {
   OneOctet = 0,
   TwoOctet = 1,
   FiveOctet = 2,
@@ -48,11 +50,11 @@ enum class PacketLengthType : uint8_t {
   Default
 };
 
-struct PacketHeader {
+struct NEOPG_UNSTABLE_API PacketHeader {
   virtual void write(std::ostream& out) = 0;
 };
 
-struct OldPacketHeader : PacketHeader {
+struct NEOPG_UNSTABLE_API OldPacketHeader : PacketHeader {
   PacketType m_packet_type;
   PacketLengthType m_length_type;
   uint32_t m_length;
@@ -72,7 +74,7 @@ struct OldPacketHeader : PacketHeader {
   void write(std::ostream& out) override;
 };
 
-struct NewPacketTag {
+struct NEOPG_UNSTABLE_API NewPacketTag {
   PacketType m_packet_type;
 
   void set_packet_type(PacketType packet_type);
@@ -82,7 +84,7 @@ struct NewPacketTag {
   void write(std::ostream& out);
 };
 
-struct NewPacketLength {
+struct NEOPG_UNSTABLE_API NewPacketLength {
   PacketLengthType m_length_type;
   uint32_t m_length;
 
@@ -99,7 +101,7 @@ struct NewPacketLength {
   void write(std::ostream& out);
 };
 
-struct NewPacketHeader : PacketHeader {
+struct NEOPG_UNSTABLE_API NewPacketHeader : PacketHeader {
   NewPacketTag m_tag;
   NewPacketLength m_length;
 

--- a/include/neopg/openpgp/literal_data_packet.h
+++ b/include/neopg/openpgp/literal_data_packet.h
@@ -12,9 +12,10 @@
 namespace NeoPG {
 namespace OpenPGP {
 
-const std::string LITERAL_DATA_CONSOLE = "_CONSOLE";
+/* FIXME: Replace with function call.  */
+const NEOPG_UNSTABLE_API std::string LITERAL_DATA_CONSOLE = "_CONSOLE";
 
-enum class LiteralDataType : uint8_t {
+enum class NEOPG_UNSTABLE_API LiteralDataType : uint8_t {
   Binary = 0x62,
   Text = 0x74,
   Utf8 = 0x75,
@@ -22,7 +23,7 @@ enum class LiteralDataType : uint8_t {
   OldLocal = 0x31
 };
 
-struct LiteralDataPacket : Packet {
+struct NEOPG_UNSTABLE_API LiteralDataPacket : Packet {
   LiteralDataType m_data_type = LiteralDataType::Binary;
   std::string m_filename;
   uint32_t m_timestamp = 0;

--- a/include/neopg/openpgp/marker_packet.h
+++ b/include/neopg/openpgp/marker_packet.h
@@ -11,7 +11,7 @@
 namespace NeoPG {
 namespace OpenPGP {
 
-struct MarkerPacket : Packet {
+struct NEOPG_UNSTABLE_API MarkerPacket : Packet {
   void write_body(std::ostream& out) const override;
   PacketType type() const override;
 };

--- a/include/neopg/openpgp/modification_detection_code_packet.h
+++ b/include/neopg/openpgp/modification_detection_code_packet.h
@@ -12,7 +12,7 @@
 namespace NeoPG {
 namespace OpenPGP {
 
-struct ModificationDetectionCodePacket : Packet {
+struct NEOPG_UNSTABLE_API ModificationDetectionCodePacket : Packet {
   std::vector<uint8_t> m_data;
 
   void write_body(std::ostream& out) const override;

--- a/include/neopg/openpgp/packet.h
+++ b/include/neopg/openpgp/packet.h
@@ -12,7 +12,7 @@
 namespace NeoPG {
 namespace OpenPGP {
 
-struct Packet {
+struct NEOPG_UNSTABLE_API Packet {
   /*! Use this to overwrite the default header.
    */
   std::unique_ptr<PacketHeader> m_header;

--- a/include/neopg/openpgp/symmetrically_encrypted_data_packet.h
+++ b/include/neopg/openpgp/symmetrically_encrypted_data_packet.h
@@ -12,7 +12,7 @@
 namespace NeoPG {
 namespace OpenPGP {
 
-struct SymmetricallyEncryptedDataPacket : Packet {
+struct NEOPG_UNSTABLE_API SymmetricallyEncryptedDataPacket : Packet {
   std::vector<uint8_t> m_data;
 
   void write_body(std::ostream& out) const override;

--- a/include/neopg/openpgp/symmetrically_encrypted_integrity_protected_data_packet.h
+++ b/include/neopg/openpgp/symmetrically_encrypted_integrity_protected_data_packet.h
@@ -12,7 +12,8 @@
 namespace NeoPG {
 namespace OpenPGP {
 
-struct SymmetricallyEncryptedIntegrityProtectedDataPacket : Packet {
+struct NEOPG_UNSTABLE_API SymmetricallyEncryptedIntegrityProtectedDataPacket
+    : Packet {
   std::vector<uint8_t> m_data;
 
   void write_body(std::ostream& out) const override;

--- a/include/neopg/openpgp/trust_packet.h
+++ b/include/neopg/openpgp/trust_packet.h
@@ -12,7 +12,7 @@
 namespace NeoPG {
 namespace OpenPGP {
 
-struct TrustPacket : Packet {
+struct NEOPG_UNSTABLE_API TrustPacket : Packet {
   std::vector<uint8_t> m_data;
 
   void write_body(std::ostream& out) const override;

--- a/include/neopg/openpgp/user_attribute_packet.h
+++ b/include/neopg/openpgp/user_attribute_packet.h
@@ -12,7 +12,7 @@
 namespace NeoPG {
 namespace OpenPGP {
 
-enum class UserAttributeType : uint8_t {
+enum class NEOPG_UNSTABLE_API UserAttributeType : uint8_t {
   Image = 0x01,
   Private_100 = 0x64,
   Private_101 = 0x65,
@@ -27,7 +27,7 @@ enum class UserAttributeType : uint8_t {
   Private_110 = 0x6e,
 };
 
-struct UserAttributePacket : Packet {
+struct NEOPG_UNSTABLE_API UserAttributePacket : Packet {
   void write_body(std::ostream& out) const override;
   PacketType type() const override;
 
@@ -37,7 +37,7 @@ struct UserAttributePacket : Packet {
 
 /* Image Attribute Subpacket.  */
 
-enum class ImageEncoding : uint8_t {
+enum class NEOPG_UNSTABLE_API ImageEncoding : uint8_t {
   JPEG = 0x01,
   Private_100 = 0x64,
   Private_101 = 0x65,
@@ -52,7 +52,7 @@ enum class ImageEncoding : uint8_t {
   Private_110 = 0x6e,
 };
 
-struct ImageAttributeSubpacket : UserAttributePacket {
+struct NEOPG_UNSTABLE_API ImageAttributeSubpacket : UserAttributePacket {
   std::vector<uint8_t> m_data;
   void write_attribute(std::ostream& out) const override;
   UserAttributeType attribute_type() const override;

--- a/include/neopg/openpgp/user_id_packet.h
+++ b/include/neopg/openpgp/user_id_packet.h
@@ -11,7 +11,7 @@
 namespace NeoPG {
 namespace OpenPGP {
 
-struct UserIdPacket : Packet {
+struct NEOPG_UNSTABLE_API UserIdPacket : Packet {
   std::string m_content;
 
   void write_body(std::ostream& out) const override;

--- a/include/neopg/proto/http.h
+++ b/include/neopg/proto/http.h
@@ -16,7 +16,7 @@
 namespace NeoPG {
 namespace Proto {
 
-class Http {
+class NEOPG_UNSTABLE_API Http {
   const long MAX_REDIRECTS_DEFAULT = 2;
   const long MAX_FILESIZE_DEFAULT = 2 * 1024 * 1024;
 

--- a/include/neopg/proto/uri.h
+++ b/include/neopg/proto/uri.h
@@ -8,10 +8,12 @@
 
 #include <string>
 
+#include <neopg/common.h>
+
 namespace NeoPG {
 namespace Proto {
 
-class URI {
+class NEOPG_DLL URI {
  public:
   std::string scheme;
   std::string authority;

--- a/include/neopg/utils/stream.h
+++ b/include/neopg/utils/stream.h
@@ -13,7 +13,7 @@
 
 namespace NeoPG {
 
-class CountingStreamBuf : public std::streambuf {
+class NEOPG_UNSTABLE_API CountingStreamBuf : public std::streambuf {
  public:
   uint32_t bytes_written();
 
@@ -26,7 +26,7 @@ class CountingStreamBuf : public std::streambuf {
   FRIEND_TEST(NeoPGTest, utils_stream_test);
 };
 
-class CountingStream : public std::ostream {
+class NEOPG_UNSTABLE_API CountingStream : public std::ostream {
  public:
   CountingStream();
   uint32_t bytes_written();

--- a/include/neopg/utils/time.h
+++ b/include/neopg/utils/time.h
@@ -14,6 +14,6 @@ namespace NeoPG {
 /**
    A replacement for timegm.
 */
-time_t NEOPG_DLL timegm(struct tm *tm);
+time_t NEOPG_UNSTABLE_API timegm(struct tm *tm);
 
 }  // namespace NeoPG

--- a/legacy/CMakeLists.txt
+++ b/legacy/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 # libgpg-error
 
-add_library(gpg-error
+add_library(gpg-error STATIC
   libgpg-error/src/gpg-error.h
   libgpg-error/src/b64dec.cpp
   libgpg-error/src/code-from-errno.cpp
@@ -43,7 +43,7 @@ target_link_libraries(gpg-error PRIVATE pthread
 target_compile_options(gpg-error PRIVATE -fpermissive
 )
 
-add_executable(gpg-error-test
+add_executable(gpg-error-test STATIC
   libgpg-error/tests/t-b64dec.cpp
   libgpg-error/tests/t-printf.cpp
   libgpg-error/tests/t-strerror.cpp
@@ -61,7 +61,7 @@ add_test(GpgErrorTest gpg-error-test COMMAND gpg-error-test test_xml_output --gt
 
 # libassuan
 
-add_library(assuan
+add_library(assuan STATIC
   libassuan/src/assuan-buffer.cpp
   libassuan/src/assuan-defs.h
   libassuan/src/assuan-error.cpp
@@ -125,7 +125,7 @@ add_test(AssuanTest assuan-test COMMAND assuan-test test_xml_output --gtest_outp
 
 # libgcrypt
 
-add_library(gcrypt
+add_library(gcrypt STATIC
   libgcrypt/src/cipher-proto.h
   libgcrypt/src/cipher.h
   libgcrypt/src/context.cpp
@@ -290,7 +290,7 @@ target_compile_options(gcrypt-secmem-test PRIVATE -fpermissive
 
 # libksba
 
-add_library(ksba
+add_library(ksba STATIC
   libksba/src/ksba.h
   libksba/src/reader.cpp
   libksba/src/writer.cpp

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,5 +1,5 @@
-# NeoPG - tests
-#   Copyright 2017 The NeoPG developers
+# NeoPG - library
+# Copyright 2017 The NeoPG developers
 #
 # NeoPG is released under the Simplified BSD License (see license.txt)
 

--- a/lib/utils/time.cpp
+++ b/lib/utils/time.cpp
@@ -1,7 +1,7 @@
 #include <boost/date_time/posix_time/conversion.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
-#include "time.h"
+#include <neopg/utils/time.h>
 
 namespace NeoPG {
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -245,6 +245,7 @@ ${BOTAN2_CFLAGS_OTHER}
 )
 
 set_target_properties(neopg-tool PROPERTIES OUTPUT_NAME "neopg")
+install(TARGETS neopg-tool RUNTIME DESTINATION bin)
 
 # Locale
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # NeoPG - tests
-#   Copyright 2017 The NeoPG developers
+# Copyright 2017 The NeoPG developers
 #
 # NeoPG is released under the Simplified BSD License (see license.txt)
 


### PR DESCRIPTION
@Sp1l pointed out that the shared library is not built.  Enabling it revealed some missing exports and other issues in the header files.  This cleans up everything so libneopg can build as a shared library. It also forces legacy code to be built and linked statically (so we don't create bogus versions of legacy libraries).  We still don't have much of a library, but a better pathway towards one.