### PR TITLE
Update PEGTL to 2.4.0.

### DIFF
--- a/lib/include/neopg/intern/pegtl.h
+++ b/lib/include/neopg/intern/pegtl.h
@@ -1,0 +1,12 @@
+// PEGTL support
+// Copyright 2017 The NeoPG developers
+//
+// NeoPG is released under the Simplified BSD License (see license.txt)
+
+#pragma once
+
+// Protect our use of PEGTL from other library users.
+#define TAO_PEGTL_NAMESPACE neopg_pegtl
+#include <tao/pegtl.hpp>
+
+namespace pegtl = tao::TAO_PEGTL_NAMESPACE;

--- a/lib/parser/openpgp.cpp
+++ b/lib/parser/openpgp.cpp
@@ -3,18 +3,15 @@
 //
 // NeoPG is released under the Simplified BSD License (see license.txt)
 
-#include <neopg/intern/cplusplus.h>
-
 #include <neopg/openpgp.h>
+
+#include <neopg/intern/cplusplus.h>
+#include <neopg/intern/pegtl.h>
 
 #include <functional>
 
-// Protect our use of PEGTL from other library users.
-#define TAOCPP_PEGTL_NAMESPACE neopg_pegtl
-#include <tao/pegtl.hpp>
-using namespace tao::neopg_pegtl;
-
 using namespace NeoPG;
+using namespace tao::neopg_pegtl;
 
 namespace openpgp {
 

--- a/lib/parser/openpgp_tests.cpp
+++ b/lib/parser/openpgp_tests.cpp
@@ -7,9 +7,6 @@
 
 #include <neopg/intern/cplusplus.h>
 
-#include <tao/pegtl.hpp>
-#include <tao/pegtl/argv_input.hpp>
-
 #include <json.hpp>
 
 #include <sstream>

--- a/lib/proto/uri.cpp
+++ b/lib/proto/uri.cpp
@@ -6,16 +6,14 @@
 
 #include <neopg/uri.h>
 
+#include <neopg/intern/pegtl.h>
+
+// Include this after neopg/intern/pegtl.h (due to namespace)!
+#include <tao/pegtl/contrib/uri.hpp>
+
 #include <iostream>
 
-// Protect our use of PEGTL from other library users.
-#define TAOCPP_PEGTL_NAMESPACE neopg_pegtl
-#include <tao/pegtl/contrib/uri.hpp>
-#include <tao/pegtl/parse.hpp>
-
 namespace NeoPG {
-
-namespace pegtl = tao::TAOCPP_PEGTL_NAMESPACE;
 
 namespace uri {
 struct grammar : pegtl::must<pegtl::uri::URI> {};


### PR DESCRIPTION
This pull request updates PEGTL to fix https://github.com/taocpp/PEGTL/pull/81 (and thus allow more than one parser).

The further changes take into account upcoming deprecations and refactor the namespace define into a header file.