### PR TITLE
Use fmtlib instead of boost::format.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ target_include_directories(neopg-tool PUBLIC
   ${BOTAN2_INCLUDE_DIRS}
   ${CLI11_INCLUDE_DIR}
   ${RANG_INCLUDE_DIR}
+  ${SPDLOG_INCLUDE_DIR}
   ../include
 )
 
@@ -269,6 +270,7 @@ target_include_directories(neopg-bin PRIVATE
   ${CLI11_INCLUDE_DIR}
   ${SPDLOG_INCLUDE_DIR}
   ${JSON_INCLUDE_DIR}
+  ${SPDLOG_INCLUDE_DIR}
   ../include
 )
 target_compile_definitions(neopg-bin PRIVATE

--- a/src/cli/packet_command.cpp
+++ b/src/cli/packet_command.cpp
@@ -18,7 +18,9 @@
 
 #include <CLI11.hpp>
 
-#include <boost/format.hpp>
+#include <spdlog/fmt/fmt.h>
+
+#include <rang.hpp>
 
 #include <iostream>
 
@@ -49,7 +51,7 @@ struct LegacyPacketSink : public RawPacketSink {
     auto new_header = dynamic_cast<NewPacketHeader*>(header.get());
 
     std::cout << "# off=" << header->m_offset
-              << " ctb=" << (boost::format("%02x") % (int)(uint8_t)head[0])
+              << " ctb=" << fmt::format("{:02x}", static_cast<int>((uint8_t)head[0]))
               << " tag=" << (int)header->type() << " hlen=" << head.length()
               << " plen=" << length << (new_header ? " new-ctb" : "") << "\n";
   }

--- a/src/neopg.cpp
+++ b/src/neopg.cpp
@@ -9,12 +9,13 @@
 
 #include <iostream>
 
+#include <spdlog/fmt/fmt.h>
 #include <spdlog/spdlog.h>
+
 #include <CLI11.hpp>
 #include <rang.hpp>
 
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/format.hpp>
 #include <boost/locale.hpp>
 
 #include <curl/curl.h>
@@ -135,9 +136,8 @@ int main(int argc, char* argv[]) {
   /* Translators, please add a second line saying "Report translation bugs to
    <...>" with the address for translation bugs (typically your translation
    team's web or email address).  */
-  app.set_footer((boost::format(_("Report bugs to %s")) %
-                  "https://github.com/das-labor/neopg")
-                     .str());
+  app.set_footer(fmt::format(_("Report bugs to {}"),
+                             "https://github.com/das-labor/neopg"));
   // app.require_subcommand(1);
   app.set_help_flag("--help", _("display help and exit"));
   app.add_subcommand("help", _("display help and exit"))


### PR DESCRIPTION
spdlog comes with a copy of fmtlib, which we want to use anyway. So we can start using it now. Legacy code is not converted immediately, as that is scheduled for eventual removal anyway.