### PR TITLE
Allow to set header factory when writing packets.

### DIFF
--- a/lib/openpgp/packet.cpp
+++ b/lib/openpgp/packet.cpp
@@ -9,15 +9,16 @@
 
 using namespace NeoPG;
 
-void Packet::write(std::ostream& out) const {
+void Packet::write(std::ostream& out,
+                   packet_header_factory header_factory) const {
   if (m_header) {
     m_header->write(out);
   } else {
     CountingStream cnt;
     write_body(cnt);
     uint32_t len = cnt.bytes_written();
-    NewPacketHeader default_header(type(), len);
-    default_header.write(out);
+    std::unique_ptr<PacketHeader> default_header = header_factory(type(), len);
+    default_header->write(out);
   }
   write_body(out);
 }

--- a/lib/openpgp/packet.h
+++ b/lib/openpgp/packet.h
@@ -7,15 +7,20 @@
 
 #include <neopg/packet_header.h>
 
+#include <functional>
 #include <memory>
 
 namespace NeoPG {
+
+using packet_header_factory = std::function<std::unique_ptr<PacketHeader>(
+    PacketType type, uint32_t length)>;
 
 struct NEOPG_UNSTABLE_API Packet {
   /// Use this to overwrite the default header.
   std::unique_ptr<PacketHeader> m_header;
 
-  void write(std::ostream& out) const;
+  void write(std::ostream& out, packet_header_factory header_factory =
+                                    NewPacketHeader::create_or_throw) const;
 
   /// Write the body of the packet to \p out.
   ///

--- a/lib/openpgp/packet_header.cpp
+++ b/lib/openpgp/packet_header.cpp
@@ -6,7 +6,14 @@
 
 #include <neopg/packet_header.h>
 
+#include <neopg/intern/cplusplus.h>
+
 namespace NeoPG {
+
+std::unique_ptr<OldPacketHeader> OldPacketHeader::create_or_throw(
+    PacketType type, uint32_t length) {
+  return NeoPG::make_unique<OldPacketHeader>(type, length);
+}
 
 void OldPacketHeader::verify_length(uint32_t length,
                                     PacketLengthType length_type) {
@@ -78,6 +85,11 @@ void OldPacketHeader::write(std::ostream& out) {
           "Unspecific packet length type (shouldn't happen).");
       // LCOV_EXCL_STOP
   }
+}
+
+std::unique_ptr<NewPacketHeader> NewPacketHeader::create_or_throw(
+    PacketType type, uint32_t length) {
+  return NeoPG::make_unique<NewPacketHeader>(type, length);
 }
 
 void NewPacketTag::set_packet_type(PacketType packet_type) {

--- a/lib/openpgp/packet_header.h
+++ b/lib/openpgp/packet_header.h
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <iostream>
+#include <memory>
 #include <stdexcept>
 
 namespace NeoPG {
@@ -72,6 +73,9 @@ class NEOPG_UNSTABLE_API OldPacketHeader : public PacketHeader {
   PacketLengthType m_length_type;
   uint32_t m_length;
 
+  static std::unique_ptr<OldPacketHeader> create_or_throw(PacketType type,
+                                                          uint32_t length);
+
   static void verify_length(uint32_t length, PacketLengthType length_type);
 
   static PacketLengthType best_length_type(uint32_t length);
@@ -122,6 +126,9 @@ class NEOPG_UNSTABLE_API NewPacketHeader : public PacketHeader {
  public:
   NewPacketTag m_tag;
   NewPacketLength m_length;
+
+  static std::unique_ptr<NewPacketHeader> create_or_throw(PacketType type,
+                                                          uint32_t length);
 
   NewPacketHeader(NewPacketTag tag, NewPacketLength length)
       : m_tag(tag), m_length(length) {}


### PR DESCRIPTION
This resolves #66 and makes writing test cases easier.