### PR TITLE
Remove --disable-signers-uid and all support for signer's uid.

### DIFF
--- a/legacy/gnupg/g10/free-packet.cpp
+++ b/legacy/gnupg/g10/free-packet.cpp
@@ -60,8 +60,6 @@ void free_seckey_enc(PKT_signature *sig) {
   xfree(sig->hashed);
   xfree(sig->unhashed);
 
-  xfree(sig->signers_uid);
-
   xfree(sig);
 }
 
@@ -170,7 +168,6 @@ PKT_signature *copy_signature(PKT_signature *d, PKT_signature *s) {
   }
   d->hashed = cp_subpktarea(s->hashed);
   d->unhashed = cp_subpktarea(s->unhashed);
-  if (s->signers_uid) d->signers_uid = xstrdup(s->signers_uid);
   if (s->numrevkeys) {
     d->revkey = NULL;
     d->numrevkeys = 0;

--- a/legacy/gnupg/g10/gpg.cpp
+++ b/legacy/gnupg/g10/gpg.cpp
@@ -1983,10 +1983,6 @@ next_pass:
         opt.throw_keyids = false;
         break;
 
-      case oDisableSignerUID:
-        opt.flags.disable_signer_uid = true;
-        break;
-
       case oS2KMode:
         opt.s2k_mode = pargs.r.ret_int;
         break;

--- a/legacy/gnupg/g10/mainproc.cpp
+++ b/legacy/gnupg/g10/mainproc.cpp
@@ -1421,11 +1421,7 @@ static int check_sig_and_print(CTX c, kbnode_t node) {
     }
   }
 
-  if (sig->signers_uid)
-    write_status_buffer(STATUS_NEWSIG, sig->signers_uid,
-                        strlen(sig->signers_uid), 0);
-  else
-    write_status_text(STATUS_NEWSIG, NULL);
+  write_status_text(STATUS_NEWSIG, NULL);
 
   astr = openpgp_pk_algo_name((pubkey_algo_t)(sig->pubkey_algo));
   if ((issuer_fpr = issuer_fpr_string(sig))) {
@@ -1442,10 +1438,6 @@ static int check_sig_and_print(CTX c, kbnode_t node) {
     log_info(_("Signature made %s using %s key ID %s\n"),
              asctimestamp(sig->timestamp), astr ? astr : "?",
              keystr(sig->keyid));
-
-  /* In verbose mode print the signers UID.  */
-  if (sig->signers_uid)
-    log_info(_("               issuer \"%s\"\n"), sig->signers_uid);
 
   rc = do_check_sig(c, node, NULL, &is_expkey, &is_revkey, &pk);
 

--- a/legacy/gnupg/g10/options.h
+++ b/legacy/gnupg/g10/options.h
@@ -307,7 +307,6 @@ struct options {
     bool utf8_filename{false};
     bool dsa2{false};
     bool large_rsa{false};
-    bool disable_signer_uid{false};
     /* Flag to enbale experimental features from RFC4880bis.  */
     bool rfc4880bis{false};
   } flags;

--- a/legacy/gnupg/g10/packet.h
+++ b/legacy/gnupg/g10/packet.h
@@ -214,9 +214,6 @@ typedef struct {
   const byte *trust_regexp;
   struct revocation_key *revkey;
   int numrevkeys;
-  char *signers_uid;      /* Malloced value of the SIGNERS_UID
-                           * subpacket or NULL.  This string has
-                           * already been sanitized.  */
   subpktarea_t *hashed;   /* All subpackets with hashed data (v4 only). */
   subpktarea_t *unhashed; /* Ditto for unhashed data. */
   /* First 2 bytes of the digest.  (Serialized.  Note: this is not

--- a/legacy/gnupg/g10/parse-packet.cpp
+++ b/legacy/gnupg/g10/parse-packet.cpp
@@ -1271,9 +1271,6 @@ static void dump_sig_subpkt(int hashed, int type, int critical,
       for (i = 0; i < length; i++)
         *listfp << ' ' << Botan::hex_encode(&buffer[i], 1);
       break;
-    case SIGSUBPKT_SIGNERS_UID:
-      p = "signer's user ID";
-      break;
     case SIGSUBPKT_REVOC_REASON:
       if (length) {
         *listfp << boost::format("revocation reason 0x%02x (") % *buffer;
@@ -1701,15 +1698,6 @@ int parse_signature(IOBUF inp, int pkttype, unsigned long pktlen,
 
     p = parse_sig_subpkt(sig->hashed, SIGSUBPKT_POLICY, NULL);
     if (p) sig->flags.policy_url = 1;
-
-    p = parse_sig_subpkt(sig->hashed, SIGSUBPKT_SIGNERS_UID, &len);
-    if (p && len) {
-      sig->signers_uid = try_make_printable_string(p, len, 0);
-      if (!sig->signers_uid) {
-        rc = gpg_error_from_syserror();
-        goto leave;
-      }
-    }
 
     p = parse_sig_subpkt(sig->hashed, SIGSUBPKT_NOTATION, NULL);
     if (p) sig->flags.notation = 1;

--- a/legacy/gnupg/g10/sign.cpp
+++ b/legacy/gnupg/g10/sign.cpp
@@ -119,33 +119,6 @@ static void mk_notation_policy_etc(PKT_signature *sig, PKT_public_key *pk,
       xfree(p);
     }
   }
-
-  /* Set signer's user id.  */
-  if (IS_SIG(sig) && !opt.flags.disable_signer_uid) {
-    char *mbox;
-
-    /* For now we use the uid which was used to locate the key.  */
-    if (pksk->user_id && (mbox = mailbox_from_userid(pksk->user_id->name))) {
-      if (DBG_LOOKUP) log_debug("setting Signer's UID to '%s'\n", mbox);
-      build_sig_subpkt(sig, SIGSUBPKT_SIGNERS_UID, (const byte *)(mbox),
-                       strlen(mbox));
-      xfree(mbox);
-    } else if (!opt.sender_list.empty()) {
-      /* If a list of --sender was given we scan that list and use
-       * the first one matching a user id of the current key.  */
-
-      /* FIXME: We need to get the list of user ids for the PKSK
-       * packet.  That requires either a function to look it up
-       * again or we need to extend the key packet struct to link
-       * to the primary key which in turn could link to the user
-       * ids.  Too much of a change right now.  Let's take just
-       * one from the supplied list and hope that the caller
-       * passed a matching one.  */
-      const std::string &sender{opt.sender_list[0]};
-      build_sig_subpkt(sig, SIGSUBPKT_SIGNERS_UID, (const byte *)sender.c_str(),
-                       sender.length());
-    }
-  }
 }
 
 /*


### PR DESCRIPTION
"Signer's UID" is a signature subpacket that is supposed to be able to indicate to the verifier of a signature which user id was used to create the signature, for example if the same signature key is used privately and for work, indicating a role under which the signature was made. Here is the relevant text from RFC4880:

> This subpacket allows a keyholder to state which User ID is
> responsible for the signing.  Many keyholders use a single key for
> different purposes, such as business communications as well as
> personal communications.  This subpacket allows such a keyholder to
> state which of their roles is making a signature.
>
> This subpacket is not appropriate to use to refer to a User Attribute
> packet.

This feature is poorly designed and implemented. It's basically a free text field that is passed on to applications, but as there is no verification on it (except that it is included in the signature hash), actually using it in applications could be very dangerous. In fact, GnuPG does not even make sure that it contains an actual user id, instead using whatever uid was used to locate the key.

As there is no valid use case, this patch removes all support for it.
