### PR TITLE
Remove neopg-tool from install taget/cmake export

### DIFF
--- a/neopg-tool/CMakeLists.txt
+++ b/neopg-tool/CMakeLists.txt
@@ -29,23 +29,14 @@ add_library(neopg-tool STATIC
 )
 add_library(neopg::neopg-tool ALIAS neopg-tool)
 target_include_directories(neopg-tool PUBLIC
-  $<INSTALL_INTERFACE:include>
-  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
-  $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
-  $<BUILD_INTERFACE:${SPDLOG_INCLUDE_DIR}>
-  $<BUILD_INTERFACE:${CLI11_INCLUDE_DIR}>
-  $<BUILD_INTERFACE:${RANG_INCLUDE_DIR}>
+  ${CMAKE_SOURCE_DIR}
+  ${CMAKE_BINARY_DIR}
+  ${SPDLOG_INCLUDE_DIR}
+  ${CLI11_INCLUDE_DIR}
+  ${RANG_INCLUDE_DIR}
 )
 target_link_libraries(neopg-tool PUBLIC
   neopg::neopg
-)
-
-install(TARGETS neopg-tool
-  EXPORT neopg
-  ARCHIVE
-    DESTINATION lib
-  PUBLIC_HEADER
-    DESTINATION include
 )
 
 # NeoPG tool (binary)
@@ -255,11 +246,11 @@ target_compile_definitions(neopg-bin PRIVATE
 
 target_link_libraries(neopg-bin
   PUBLIC
-  neopg::neopg-tool
   Boost::locale
   PkgConfig::libusb-1.0
   Threads::Threads
   PRIVATE
+  neopg::neopg-tool
   neopg::gpg-error
   neopg::assuan
   neopg::gcrypt
@@ -272,18 +263,6 @@ install(TARGETS neopg-bin
   EXPORT neopg
   RUNTIME
     DESTINATION bin
-  PUBLIC_HEADER
-    DESTINATION include
-)
-
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/neopg-tool/cli
-  DESTINATION include/neopg-tool
-  FILES_MATCHING PATTERN *.h
-)
-
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/neopg-tool/io
-  DESTINATION include/neopg-tool
-  FILES_MATCHING PATTERN *.h
 )
 
 # Tests


### PR DESCRIPTION
There was a last missing review fix from https://github.com/das-labor/neopg/pull/90#issuecomment-433456780
> And libneopg-tool exists only to allow for creating a separate testing binary that does unit testing with code from the main program.

With this PR, this review findings are also fixed. Libneopg-tool puls header files will not installed anymore with "install" target.